### PR TITLE
allow to skip installation of prerequisites

### DIFF
--- a/docs/http-challenge/s3.md
+++ b/docs/http-challenge/s3.md
@@ -1,11 +1,12 @@
 # Variables for s3 http-challenge
 
-| Variable              | Required | Default   | Description
-|-----------------------|----------|-----------|------------
-| acme_s3_bucket_name   | yes      |           | name of the s3 bucket which should be used
-| acme_s3_access_key    | yes      |           | aws access key for API user of s3 bucket
-| acme_s3_secret_key    | yes      |           | aws secret key for API user of s3 bucket
-| acme_s3_config_region | no       | us-west-1 | aws s3 region in which bucket can be found
+| Variable                      | Required | Default   | Description
+|-------------------------------|----------|-----------|------------
+| acme_s3_bucket_name           | yes      |           | name of the s3 bucket which should be used
+| acme_s3_access_key            | yes      |           | aws access key for API user of s3 bucket
+| acme_s3_secret_key            | yes      |           | aws secret key for API user of s3 bucket
+| acme_s3_config_region         | no       | us-west-1 | aws s3 region in which bucket can be found
+| acme_s3_install_prerequisites | no       | true      | install python-boto3 as prerequisit for s3 challenge file upload
 
 ## Validation
 

--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -19,5 +19,6 @@ acme_remaining_days: "30"
 
 ### provider specific config
 acme_s3_config_region: eu-west-1
+acme_s3_install_prerequisites: true
 acme_local_validation_path: /var/www/html
 acme_azure_purge_state: absent

--- a/roles/acme/tasks/challenge/http-01/s3.yml
+++ b/roles/acme/tasks/challenge/http-01/s3.yml
@@ -6,6 +6,8 @@
       - python-boto3
     state: present
     use: "{{ acme_prerequisites_packagemanager }}"
+  when:
+    - acme_s3_install_prerequisites | bool
 
 - name: Validate challenge only if it is created or changed # noqa no-handler
   when: acme_challenge is changed


### PR DESCRIPTION
Some Users maybe want to install boto3 by pip. With `acme_s3_install_prerequisites: false` ist is possible to skip Installation of this prerequisit.