### PR TITLE
feat: add certificate download for temporary environments

### DIFF
--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -22,3 +22,6 @@ acme_s3_config_region: eu-west-1
 acme_s3_install_prerequisites: true
 acme_local_validation_path: /var/www/html
 acme_azure_purge_state: absent
+
+### certificate download for non-persistent environments
+acme_download_cert: false

--- a/roles/acme/tasks/challenge/http-01/s3.yml
+++ b/roles/acme/tasks/challenge/http-01/s3.yml
@@ -25,8 +25,8 @@
 
     - name: Upload challenge file for SAN domain to s3 bucket
       amazon.aws.s3_object:
-        aws_access_key: "{{ acme_s3_access_key }}"
-        aws_secret_key: "{{ acme_s3_secret_key }}"
+        access_key: "{{ acme_s3_access_key }}"
+        secret_key: "{{ acme_s3_secret_key }}"
         bucket: "{{ acme_s3_bucket_name }}"
         object: "{{ acme_challenge['challenge_data'][item]['http-01']['resource'] }}"
         src: acme-challenge.{{ item }}
@@ -58,8 +58,8 @@
 
     - name: Remove challenge file for SAN domain from s3 bucket
       amazon.aws.s3_object:
-        aws_access_key: "{{ acme_s3_access_key }}"
-        aws_secret_key: "{{ acme_s3_secret_key }}"
+        access_key: "{{ acme_s3_access_key }}"
+        secret_key: "{{ acme_s3_secret_key }}"
         bucket: "{{ acme_s3_bucket_name }}"
         object: "{{ acme_challenge['challenge_data'][item]['http-01']['resource'] }}"
         mode: delobj

--- a/roles/acme/tasks/download_cert.yml
+++ b/roles/acme/tasks/download_cert.yml
@@ -1,0 +1,13 @@
+---
+- name: Fetch current certificate from https server
+  community.crypto.get_certificate:
+    host: "{{ acme_cert_download_host | default(acme_domain.subject_alt_name[0]) }}"
+    port: "{{ acme_cert_download_port | default('443') }}"
+    server_name: "{{ acme_cert_san_name | default(acme_domain.subject_alt_name[0]) }}"
+  register: certificate
+
+- name: Write fetched certificate to file
+  ansible.builtin.copy:
+    content: "{{ certificate.cert }}"
+    dest: "{{ acme_cert_path }}"
+    mode: "0644"

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -2,6 +2,11 @@
 - name: Preconditions
   ansible.builtin.include_tasks: preconditions.yml
 
+- name: Download Certificate from https
+  ansible.builtin.include_tasks: download_cert.yml
+  when:
+    - acme_download_cert
+
 - name: Run key generation
   ansible.builtin.include_tasks: create-keys.yml
 

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -1,25 +1,32 @@
 ---
 - name: Preconditions
-  ansible.builtin.include_tasks: preconditions.yml
+  ansible.builtin.include_tasks:
+    file: preconditions.yml
 
 - name: Download Certificate from https
-  ansible.builtin.include_tasks: download_cert.yml
+  ansible.builtin.include_tasks:
+    file: download_cert.yml
   when:
     - acme_download_cert
 
 - name: Run key generation
-  ansible.builtin.include_tasks: create-keys.yml
+  ansible.builtin.include_tasks:
+    file: create-keys.yml
 
 - name: Create csr
-  ansible.builtin.include_tasks: create-csr.yml
+  ansible.builtin.include_tasks:
+    file: create-csr.yml
 
 - name: Create challenge
-  ansible.builtin.include_tasks: create-challenge.yml
+  ansible.builtin.include_tasks:
+    file: create-challenge.yml
 
 - name: Do challenge with provider {{ acme_challenge_provider }}
-  ansible.builtin.include_tasks: "{{ acme_provider_path }}"
+  ansible.builtin.include_tasks:
+    file: "{{ acme_provider_path }}"
 
 - name: Convert certificate
-  ansible.builtin.include_tasks: convert_certificate.yml
+  ansible.builtin.include_tasks:
+    file: convert_certificate.yml
   when:
     - acme_convert_cert_to is defined


### PR DESCRIPTION
community.crypto.acme_certificate does use the existing certificate file to check for the validity in order to decide whether a certificate needs renewal.

As this file isn't kept if running the playbook on a non persistent environment such as a containerized ci runner this leads to a certificate renewal on each playbook execution which might hit the limit of 5 certs per seven days as configured on letsencrypt depending on the configured schedule.

By downloading the certificate from the webserver beforehand to the certificate file this check should work as expected again