### PR TITLE
role should be usable via include_role, vars should be possible via loop

### DIFF
--- a/docs/http-challenge/azbs.md
+++ b/docs/http-challenge/azbs.md
@@ -74,3 +74,43 @@ rewrite \.well-known/acme-challenge/(.*) https://your-storage-account-name.blob.
               ...
     acme_azbs_tenant_id: "2132184-3534543-54354-3543"
 ```
+
+```yaml
+---
+- name: Lets Encrypt certificates
+  hosts: localhost
+  vars:
+    acme_account_email: "ssl-admin@example.com"
+    acme_challenge_provider: "azbs"
+    acme_use_live_directory: true
+    acme_convert_cert_to: pfx
+    acme_azbs_resource_group: "my-resource-group"
+    acme_azbs_storage_account_name: "my-storage-account-name"
+    acme_azbs_container_name: "my-container"
+    acme_azbs_subscription_id: "0000-11111-2222-3333-444444"
+    acme_azbs_tenant_id: "2132184-3534543-54354-3543"
+    acme_azbs_client_id: "1234-21231-14152-1231"
+    acme_azbs_secret: !vault |
+              $ANSIBLE_VAULT;1.1;AES256
+              ...
+    az_acme_certificates:
+      example-com:
+        zone: example.com
+        subject_alt_name: [ example.com, domain1.example.com, domain2.example.com ]
+      example2-com:
+        zone: example2.com
+        subject_alt_name: [ example2.com, domain1.example2.com, domain2.example2.com ]
+  tasks:
+    - name: Create and upload Lets Encrypt certificates
+      ansible.builtin.include_role:
+        name: telekom_mms.acme.acme
+      vars:
+        acme_domain:
+          email_address: "ssl-admin@example.com"
+          certificate_name: "{{ certificate.key }}"
+          zone: "{{ certificate.value.zone }}"
+          subject_alt_name: "{{ certificate.value.subject_alt_name }}"
+      loop: "{{ az_acme_certificates | dict2items }}"
+      loop_control:
+        loop_var: certificate
+```

--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ### global
-acme_domain: {}
+acme_domain: { }
 acme_conf_dir: "{{ lookup('env', 'HOME') }}/letsencrypt"
 acme_cert_dir: "{{ acme_conf_dir }}/certs"
 acme_prerequisites_packagemanager: yum

--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ### global
-acme_domain: []
+acme_domain: {}
 acme_conf_dir: "{{ lookup('env', 'HOME') }}/letsencrypt"
 acme_cert_dir: "{{ acme_conf_dir }}/certs"
 acme_prerequisites_packagemanager: yum

--- a/roles/acme/defaults/main.yml
+++ b/roles/acme/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 ### global
+acme_domain: []
 acme_conf_dir: "{{ lookup('env', 'HOME') }}/letsencrypt"
 acme_cert_dir: "{{ acme_conf_dir }}/certs"
 acme_prerequisites_packagemanager: yum

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -12,26 +12,21 @@
 - name: Run key generation
   ansible.builtin.include_tasks:
     file: create-keys.yml
-  # when: acme_domain | length > 0
 
 - name: Create csr
   ansible.builtin.include_tasks:
     file: create-csr.yml
-  # when: acme_domain | length > 0
 
 - name: Create challenge
   ansible.builtin.include_tasks:
     file: create-challenge.yml
-  # when: acme_domain | length > 0
 
 - name: Do challenge with provider {{ acme_challenge_provider }}
   ansible.builtin.include_tasks:
     file: "{{ acme_provider_path }}"
-  # when: acme_domain | length > 0
 
 - name: Convert certificate
   ansible.builtin.include_tasks:
     file: convert_certificate.yml
   when:
     - acme_convert_cert_to is defined
-    # - acme_domain | length > 0

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -12,21 +12,26 @@
 - name: Run key generation
   ansible.builtin.include_tasks:
     file: create-keys.yml
+  when: acme_domain | length > 0
 
 - name: Create csr
   ansible.builtin.include_tasks:
     file: create-csr.yml
+  when: acme_domain | length > 0
 
 - name: Create challenge
   ansible.builtin.include_tasks:
     file: create-challenge.yml
+  when: acme_domain | length > 0
 
 - name: Do challenge with provider {{ acme_challenge_provider }}
   ansible.builtin.include_tasks:
     file: "{{ acme_provider_path }}"
+  when: acme_domain | length > 0
 
 - name: Convert certificate
   ansible.builtin.include_tasks:
     file: convert_certificate.yml
   when:
     - acme_convert_cert_to is defined
+    - acme_domain | length > 0

--- a/roles/acme/tasks/main.yml
+++ b/roles/acme/tasks/main.yml
@@ -12,26 +12,26 @@
 - name: Run key generation
   ansible.builtin.include_tasks:
     file: create-keys.yml
-  when: acme_domain | length > 0
+  # when: acme_domain | length > 0
 
 - name: Create csr
   ansible.builtin.include_tasks:
     file: create-csr.yml
-  when: acme_domain | length > 0
+  # when: acme_domain | length > 0
 
 - name: Create challenge
   ansible.builtin.include_tasks:
     file: create-challenge.yml
-  when: acme_domain | length > 0
+  # when: acme_domain | length > 0
 
 - name: Do challenge with provider {{ acme_challenge_provider }}
   ansible.builtin.include_tasks:
     file: "{{ acme_provider_path }}"
-  when: acme_domain | length > 0
+  # when: acme_domain | length > 0
 
 - name: Convert certificate
   ansible.builtin.include_tasks:
     file: convert_certificate.yml
   when:
     - acme_convert_cert_to is defined
-    - acme_domain | length > 0
+    # - acme_domain | length > 0

--- a/roles/acme/tasks/preconditions.yml
+++ b/roles/acme/tasks/preconditions.yml
@@ -10,7 +10,7 @@
   ansible.builtin.assert:
     that:
       - acme_domain is defined
-      - acme_domain != []
+      - acme_domain != {}
     fail_msg: You need to set acme_domain. See documentation for a list of possibilities.
 
 - name: Set fact for acme_directory depending on what is set in acme_use_live_directory

--- a/roles/acme/tasks/preconditions.yml
+++ b/roles/acme/tasks/preconditions.yml
@@ -6,6 +6,13 @@
       - acme_challenge_provider != ""
     fail_msg: You need to set acme_challenge_provider with a provider. See documentation for a list of possible providers.
 
+- name: Check if a acme_domain is set
+  ansible.builtin.assert:
+    that:
+      - acme_domain is defined
+      - acme_domain != []
+    fail_msg: You need to set acme_domain. See documentation for a list of possibilities.
+
 - name: Set fact for acme_directory depending on what is set in acme_use_live_directory
   ansible.builtin.set_fact:
     acme_directory: "{{ acme_use_live_directory | ternary(acme_live_directory, acme_staging_directory) }}"
@@ -27,10 +34,3 @@
     - challenge/dns-01/{{ acme_challenge_provider }}.yml
     - challenge/http-01/{{ acme_challenge_provider }}.yml
     - challenge-unknown.yml
-
-- name: Check if a acme_domain is set
-  ansible.builtin.assert:
-    that:
-      - acme_domain is defined
-      - acme_domain != []
-    fail_msg: You need to set acme_domain. See documentation for a list of possibilities.

--- a/roles/acme/tasks/preconditions.yml
+++ b/roles/acme/tasks/preconditions.yml
@@ -27,3 +27,10 @@
     - challenge/dns-01/{{ acme_challenge_provider }}.yml
     - challenge/http-01/{{ acme_challenge_provider }}.yml
     - challenge-unknown.yml
+
+- name: Check if a acme_domain is set
+  ansible.builtin.assert:
+    that:
+      - acme_domain is defined
+      - acme_domain != []
+    fail_msg: You need to set acme_domain. See documentation for a list of possibilities.

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-include-role.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-include-role.yml
@@ -20,6 +20,9 @@
         acme_validate_certs: false
   post_tasks:
     - name: Validate certs
+      vars:
+        acme_domain:
+          certificate_name: dns-pebble.example.com
       community.crypto.x509_certificate_info:
         path: "{{ acme_cert_path }}"
       register: result

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-include-role.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-include-role.yml
@@ -1,0 +1,35 @@
+---
+- name: Test if include_role is working
+  hosts: localhost
+  tasks:
+    - name: Create and upload Lets Encrypt certificates
+      ansible.builtin.include_role:
+        name: telekom_mms.acme.acme
+        public: yes
+      vars:
+        acme_domain:
+          certificate_name: dns-pebble.example.com
+          zone: example.com
+          email_address: ssl-admin@example.com
+          subject_alt_name:
+            - example.com
+        acme_challenge_provider: pebble
+        acme_use_live_directory: false
+        acme_account_email: ssl-admin@example.com
+        acme_staging_directory: https://localhost:14000/dir
+        acme_validate_certs: false
+  post_tasks:
+    - name: Validate certs
+      community.crypto.x509_certificate_info:
+        path: "{{ acme_cert_path }}"
+      register: result
+
+    - name: Print the certificate
+      ansible.builtin.debug:
+        msg: "{{ result }}"
+
+    - name: Check if the certificate is correct
+      ansible.builtin.assert:
+        that:
+          - "'DNS:example.com' in result.subject_alt_name"
+          - "'Pebble Intermediate CA' in result.issuer.commonName"

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-include-role.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-include-role.yml
@@ -5,7 +5,7 @@
     - name: Create and upload Lets Encrypt certificates
       ansible.builtin.include_role:
         name: telekom_mms.acme.acme
-        public: yes
+        public: true
       vars:
         acme_domain:
           certificate_name: dns-pebble.example.com

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-missing-acme-domain.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-missing-acme-domain.yml
@@ -9,4 +9,4 @@
     acme_account_email: ssl-admin@example.com
     acme_staging_directory: https://localhost:14000/dir
     acme_validate_certs: false
-  ignore_errors: yes
+  ignore_errors: true

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-missing-acme-domain.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-missing-acme-domain.yml
@@ -9,3 +9,4 @@
     acme_account_email: ssl-admin@example.com
     acme_staging_directory: https://localhost:14000/dir
     acme_validate_certs: false
+  ignore_errors: yes

--- a/tests/integration/targets/acme_letsencrypt/dns-challenge-missing-acme-domain.yml
+++ b/tests/integration/targets/acme_letsencrypt/dns-challenge-missing-acme-domain.yml
@@ -1,0 +1,11 @@
+---
+- name: Test role if acme_domain is not set
+  hosts: localhost
+  roles:
+    - telekom_mms.acme.acme
+  vars:
+    acme_challenge_provider: pebble
+    acme_use_live_directory: false
+    acme_account_email: ssl-admin@example.com
+    acme_staging_directory: https://localhost:14000/dir
+    acme_validate_certs: false

--- a/tests/integration/targets/acme_letsencrypt/runme.sh
+++ b/tests/integration/targets/acme_letsencrypt/runme.sh
@@ -4,3 +4,5 @@ set -eux
 
 ansible-playbook dns-challenge-pebble.yml
 ansible-playbook http-challenge-local.yml
+ansible-playbook dns-challenge-include-role.yml
+ansible-playbook dns-challenge-missing-acme-domain.yml


### PR DESCRIPTION
At the moment the acme role can only use acme_domain in the vars, e.g.
```
---
- name: Lets Encrypt certificates
  hosts: localhost
  collections:
    - telekom_mms.acme
  roles:
    - telekom_mms.acme.acme
  vars:
    acme_domain:
      email_address: "{{ service_email }}"
      certificate_name: domain
      zone: www.domain.com
      subject_alt_name: ["domain.com"]
```

Due to the fact that we have more than 100 domains it would be nice if we can loop over the domains. 
So the that the role also should be work over `ansible.builtin.include_role`
So that the code should like, e.g.
```
---
- name: Lets Encrypt certificates
  hosts: localhost
  tasks:
    - name: Create and upload Lets Encrypt certificates
      ansible.builtin.include_role:
        name: telekom_mms.acme.acme
      vars:
        acme_domain:
          email_address: "{{ service_email }}"
          certificate_name: "{{ certificate.key }}"
          zone: "{{ certificate.value.zone }}"
          subject_alt_name: "{{ certificate.value.subject_alt_name }}"
      loop: "{{ certificates | dict2items }}"
      loop_control:
        loop_var: certificate
```