### PR TITLE
Fixing missing endpoint_url on remove task

### DIFF
--- a/roles/acme/tasks/challenge/http-01/s3.yml
+++ b/roles/acme/tasks/challenge/http-01/s3.yml
@@ -65,6 +65,7 @@
         object: "{{ acme_challenge_data[item]['http-01']['resource'] }}"
         mode: delobj
         region: "{{ acme_s3_config_region }}"
+        endpoint_url: "{{ acme_s3_endpoint_url | default(omit) }}"
       loop: "{{ acme_domain.subject_alt_name }}"
       when:
         - acme_domain.subject_alt_name is defined


### PR DESCRIPTION
The endpoint_url parameter was introduced in one of the last changesets. This parameters was missing on the remove task and therefore the create task will use the alternative endpoint_url, but the remove task will contact Amzn S3.