### PR TITLE
chore: add missing link to nsupdate doc

### DIFF
--- a/docs/role-acme.md
+++ b/docs/role-acme.md
@@ -16,6 +16,7 @@ Feel free to contribute more DNS or HTTP APIs :)
   * [Azure](/docs/dns-challenge/azure.md)
   * [Domain Offensive](/docs/dns-challenge/domain-offensive.md)
   * [hetzner](/docs/dns-challenge/hetzner.md)
+  * [nsupdate](/docs/dns-challenge/nsupdate.md)
   * [openstack](/docs/dns-challenge/openstack.md)
   * [pebble](/docs/dns-challenge/pebble.md)
 * HTTP-01


### PR DESCRIPTION
This adds the missing link to the nsupdate docs.